### PR TITLE
resolve inconsistent Docker build failure due to invalid image tag

### DIFF
--- a/deployment/Dockerfile.llama-server
+++ b/deployment/Dockerfile.llama-server
@@ -1,5 +1,5 @@
 # use llama-cpp server for OpenAI API compatible LLM service
-FROM ghcr.io/ggml-org/llama.cpp:server:b8763
+FROM ghcr.io/ggml-org/llama.cpp:server-b8763
 
 # copy the specified gguf file from repo models/ to container models/
 COPY models/$GGUF_FILE models/


### PR DESCRIPTION
The previous image reference used ':' instead of '-' (server:b8763),
which does not exist and caused build failures on some systems. (Sai had a build failure)
Updated to 'server-b8763' to match the published image!